### PR TITLE
Update country name for Macedonia

### DIFF
--- a/lib/country-select.rb
+++ b/lib/country-select.rb
@@ -170,7 +170,7 @@ module ActionView
         "Lithuania",
         "Luxembourg",
         "Macao",
-        "Macedonia, Republic Of",
+        "Republic of North Macedonia",
         "Madagascar",
         "Malawi",
         "Malaysia",


### PR DESCRIPTION
Earlier this year the Macedonian Government renamed the country from
"Republic of Macedonia" to "Republic of North Macedonia". This change
doesn't automatically propagate into FreeAgent as we maintain our own
list of country names (a fork of the country-select gem). This PR
updates the country name on request of a customer (who has raised
several support requests and for which Support Engineering have been
manually updating invoices until now).

https://www.bbc.co.uk/news/world-europe-46846231